### PR TITLE
Add Cvar to remove broken frames from renders

### DIFF
--- a/src/Features/Demo/Demo.hpp
+++ b/src/Features/Demo/Demo.hpp
@@ -16,6 +16,7 @@ public:
     int32_t playbackFrames;
     int32_t signOnLength;
     std::vector<int32_t> messageTicks;
+    int32_t firstPositivePacketTick;
     int32_t segmentTicks;
 
 public:

--- a/src/Features/Demo/DemoParser.cpp
+++ b/src/Features/Demo/DemoParser.cpp
@@ -91,6 +91,10 @@ bool DemoParser::Parse(std::string filePath, Demo* demo, bool ghostRequest, std:
                 case 0x01: // SignOn
                 case 0x02: // Packet
                 {
+                    if (tick > 0 && (demo->firstPositivePacketTick == 0 || demo->firstPositivePacketTick > tick)) {
+                        demo->firstPositivePacketTick = tick;
+                    }
+
                     if (outputMode == 2 || ghostRequest == true) {
                         for (auto i = 0; i < this->maxSplitScreenClients; ++i) {
                             if (i >= 1) {

--- a/src/Features/Renderer.hpp
+++ b/src/Features/Renderer.hpp
@@ -4,5 +4,6 @@ namespace Renderer {
     void Frame();
     void Init(void **videomode);
     extern int segmentEndTick;
+    extern int demoStart;
     extern bool isDemoLoading;
 };

--- a/src/Modules/EngineDemoPlayer.cpp
+++ b/src/Modules/EngineDemoPlayer.cpp
@@ -142,7 +142,7 @@ DETOUR(EngineDemoPlayer::StartPlayback, const char* filename, bool bAsTimeDemo)
             console->Print("Time:     %.3f\n", demo.playbackTime);
             console->Print("Tickrate: %.3f\n", demo.Tickrate());
             engine->demoplayer->levelName = demo.mapName;
-
+            Renderer::demoStart = demo.firstPositivePacketTick;
             Renderer::segmentEndTick = demo.segmentTicks;
 
 #ifdef SAR_MODERATOR_BUILD


### PR DESCRIPTION
This also resolves the issue of starting on even/odd ticks, because it falls to sv_alternateticks 0 resolution when removing frames. This isn't super well tested, but I don't believe it should cause any issues.